### PR TITLE
feat: Phase 1 New Architecture migration (v2.0.0-alpha.0)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,32 +1,25 @@
 import groovy.json.JsonSlurper
 
-def sdkVersions = new JsonSlurper().parse file("../sdk-versions.json")
-
-buildscript {
-  // Buildscript is evaluated before everything else so we can't use getExtOrDefault
-  def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["ReactNativeVideoPlugin_kotlinVersion"]
-
-  repositories {
-    google()
-    mavenCentral()
-  }
-
-  dependencies {
-    classpath "com.android.tools.build:gradle:8.7.2"
-    // noinspection DifferentKotlinGradleVersion
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-  }
+// Use the `plugins {}` DSL block so the React Native gradle plugin resolves
+// in both legacy consumers (root buildscript classpath) AND modern RN 0.71+
+// consumers (pluginManagement.includeBuild in settings.gradle). The legacy
+// `apply plugin: 'com.facebook.react'` form only works against legacy classpath
+// setups, breaking vanilla RN 0.71+ templates.
+//
+// Plugins (AGP, Kotlin, com.facebook.react) are inherited from the consumer
+// app's classpath — declaring our own `buildscript {}` block creates a parallel
+// classloader hierarchy and triggers a "privateReact extension already
+// registered" error when both this lib and a sibling lib apply the React plugin.
+plugins {
+  id "com.android.library"
+  id "kotlin-android"
+  id "com.facebook.react"
 }
+
+def sdkVersions = new JsonSlurper().parse file("../sdk-versions.json")
 
 def isNewArchitectureEnabled() {
   return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
-}
-
-apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
-
-if (isNewArchitectureEnabled()) {
-  apply plugin: "com.facebook.react"
 }
 
 def getExtOrDefault(name) {
@@ -57,6 +50,16 @@ android {
     }
   }
 
+  sourceSets {
+    main {
+      if (isNewArchitectureEnabled()) {
+        java.srcDirs += ['src/newarch']
+      } else {
+        java.srcDirs += ['src/oldarch']
+      }
+    }
+  }
+
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
@@ -79,6 +82,12 @@ android {
     sourceCompatibility JavaVersion.VERSION_17
     targetCompatibility JavaVersion.VERSION_17
   }
+}
+
+react {
+  jsRootDir = file("../src/specs/")
+  libraryName = "RNVideoPluginSpec"
+  codegenJavaPackageName = "com.hms.reactnativevideoplugin"
 }
 
 repositories {

--- a/android/src/main/java/com/hms/reactnativevideoplugin/ReactNativeVideoPluginModuleImpl.kt
+++ b/android/src/main/java/com/hms/reactnativevideoplugin/ReactNativeVideoPluginModuleImpl.kt
@@ -5,21 +5,19 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import com.reactnativehmssdk.HMSManager
+import com.reactnativehmssdk.HMSManagerImpl
 import com.reactnativehmssdk.HMSRNSDK
 import live.hms.video.error.HMSException
 import live.hms.video.sdk.HMSActionResultListener
 import live.hms.video.virtualbackground.HMSVirtualBackground
 import java.net.URL
 
-class ReactNativeVideoPluginModule(reactContext: ReactApplicationContext) :
-  ReactContextBaseJavaModule(reactContext) {
+class ReactNativeVideoPluginModuleImpl(
+  private val reactApplicationContext: ReactApplicationContext,
+) {
   private var virtualBackgroundPlugin: HMSVirtualBackground? = null
 
-  @ReactMethod
   fun changeVirtualBackground(
     data: ReadableMap,
     promise: Promise?,
@@ -101,7 +99,6 @@ class ReactNativeVideoPluginModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  @ReactMethod
   fun disableVideoPlugin(
     data: ReadableMap,
     promise: Promise?,
@@ -128,7 +125,7 @@ class ReactNativeVideoPluginModule(reactContext: ReactApplicationContext) :
     }
     when (pluginType) {
       "HMSVirtualBackgroundPlugin" -> {
-        val moduleInstance = this
+        val implInstance = this
         hmsSDK.removePlugin(
           virtualBackgroundPlugin,
           object : HMSActionResultListener {
@@ -138,7 +135,7 @@ class ReactNativeVideoPluginModule(reactContext: ReactApplicationContext) :
 
             override fun onSuccess() {
               promise?.resolve(true)
-              moduleInstance.virtualBackgroundPlugin = null
+              implInstance.virtualBackgroundPlugin = null
             }
           },
         )
@@ -149,7 +146,6 @@ class ReactNativeVideoPluginModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  @ReactMethod
   fun enableVideoPlugin(
     data: ReadableMap,
     promise: Promise?,
@@ -183,15 +179,11 @@ class ReactNativeVideoPluginModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun getName(): String {
-    return NAME
-  }
-
   private fun getHmsRNSdk(data: ReadableMap): HMSRNSDK? {
     val id = data.getString("id")
 
     return if (id != null) {
-      HMSManager.hmsCollection[id]
+      HMSManagerImpl.hmsCollection[id]
     } else {
       null
     }

--- a/android/src/main/java/com/hms/reactnativevideoplugin/ReactNativeVideoPluginPackage.kt
+++ b/android/src/main/java/com/hms/reactnativevideoplugin/ReactNativeVideoPluginPackage.kt
@@ -1,16 +1,35 @@
 package com.hms.reactnativevideoplugin
 
-import com.facebook.react.ReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.uimanager.ViewManager
+import com.facebook.react.module.model.ReactModuleInfo
+import com.facebook.react.module.model.ReactModuleInfoProvider
 
-class ReactNativeVideoPluginPackage : ReactPackage {
-  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-    return listOf(ReactNativeVideoPluginModule(reactContext))
-  }
+class ReactNativeVideoPluginPackage : BaseReactPackage() {
+  override fun getModule(
+    name: String,
+    reactContext: ReactApplicationContext,
+  ): NativeModule? =
+    if (name == ReactNativeVideoPluginModuleImpl.NAME) {
+      ReactNativeVideoPluginModule(reactContext)
+    } else {
+      null
+    }
 
-  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-    return emptyList()
-  }
+  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider =
+    ReactModuleInfoProvider {
+      mapOf(
+        ReactNativeVideoPluginModuleImpl.NAME to
+          ReactModuleInfo(
+            ReactNativeVideoPluginModuleImpl.NAME,
+            ReactNativeVideoPluginModuleImpl.NAME,
+            false, // canOverrideExistingModule
+            false, // needsEagerInit
+            false, // hasConstants
+            false, // isCxxModule
+            true,  // isTurboModule
+          ),
+      )
+    }
 }

--- a/android/src/newarch/java/com/hms/reactnativevideoplugin/ReactNativeVideoPluginModule.kt
+++ b/android/src/newarch/java/com/hms/reactnativevideoplugin/ReactNativeVideoPluginModule.kt
@@ -1,0 +1,30 @@
+package com.hms.reactnativevideoplugin
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.module.annotations.ReactModule
+
+@ReactModule(name = ReactNativeVideoPluginModuleImpl.NAME)
+class ReactNativeVideoPluginModule(
+  reactContext: ReactApplicationContext,
+) : NativeReactNativeVideoPluginSpec(reactContext) {
+  private val impl = ReactNativeVideoPluginModuleImpl(reactContext)
+
+  override fun getName(): String = ReactNativeVideoPluginModuleImpl.NAME
+
+  override fun changeVirtualBackground(
+    data: ReadableMap,
+    promise: Promise,
+  ) = impl.changeVirtualBackground(data, promise)
+
+  override fun enableVideoPlugin(
+    data: ReadableMap,
+    promise: Promise,
+  ) = impl.enableVideoPlugin(data, promise)
+
+  override fun disableVideoPlugin(
+    data: ReadableMap,
+    promise: Promise,
+  ) = impl.disableVideoPlugin(data, promise)
+}

--- a/android/src/oldarch/java/com/hms/reactnativevideoplugin/ReactNativeVideoPluginModule.kt
+++ b/android/src/oldarch/java/com/hms/reactnativevideoplugin/ReactNativeVideoPluginModule.kt
@@ -1,0 +1,35 @@
+package com.hms.reactnativevideoplugin
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.module.annotations.ReactModule
+
+@ReactModule(name = ReactNativeVideoPluginModuleImpl.NAME)
+class ReactNativeVideoPluginModule(
+  reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+  private val impl = ReactNativeVideoPluginModuleImpl(reactContext)
+
+  override fun getName(): String = ReactNativeVideoPluginModuleImpl.NAME
+
+  @ReactMethod
+  fun changeVirtualBackground(
+    data: ReadableMap,
+    promise: Promise?,
+  ) = impl.changeVirtualBackground(data, promise)
+
+  @ReactMethod
+  fun enableVideoPlugin(
+    data: ReadableMap,
+    promise: Promise?,
+  ) = impl.enableVideoPlugin(data, promise)
+
+  @ReactMethod
+  fun disableVideoPlugin(
+    data: ReadableMap,
+    promise: Promise?,
+  ) = impl.disableVideoPlugin(data, promise)
+}

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -22,6 +22,11 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.7.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+        // Expose com.facebook.react on the buildscript classpath so that
+        // transitive libraries using legacy `apply plugin: 'com.facebook.react'`
+        // syntax (e.g. lottie-react-native) resolve under new-arch builds.
+        // Modern `plugins {}` block consumers don't need this.
+        classpath("com.facebook.react:react-native-gradle-plugin")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -15,5 +15,12 @@ extensions.configure(com.facebook.react.ReactSettingsExtension){ ex ->
     ex.autolinkLibrariesFromCommand()
 }
 
+// Expose @react-native/gradle-plugin to regular Gradle dependency resolution
+// (in addition to plugin resolution above) so libraries using legacy
+// `apply plugin: 'com.facebook.react'` can find it on the root buildscript
+// classpath. Required for new-arch builds with transitive libs like
+// lottie-react-native that conditionally use legacy plugin syntax.
+includeBuild("../node_modules/@react-native/gradle-plugin")
+
 rootProject.name = 'ReactNativeVideoPluginExample'
 include ':app'

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@100mslive/react-native-hms": "file:../../100ms-react-native/packages/react-native-hms",
+    "@100mslive/react-native-hms": "^2.0.0-alpha.1",
     "@100mslive/react-native-room-kit": "1.2.3",
     "@100mslive/react-native-video-plugin": "workspace:^",
     "@100mslive/types-prebuilt": "0.12.12",

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@100mslive/react-native-hms": ">=1.12.0 <2.0.0",
+    "@100mslive/react-native-hms": "file:../../100ms-react-native/packages/react-native-hms",
     "@100mslive/react-native-room-kit": "1.2.3",
     "@100mslive/react-native-video-plugin": "workspace:^",
     "@100mslive/types-prebuilt": "0.12.12",

--- a/package.json
+++ b/package.json
@@ -155,10 +155,20 @@
     "minimatch": "^10.2.1",
     "js-yaml": "^4.1.1"
   },
+  "//peerDependenciesTodo": "TODO: bump @100mslive/react-native-hms peer-dep to >=2.0.0-alpha.X once Phase 1 New Architecture migration is published. The 2.0.0-alpha.0 currently on npm (2023-10-05) predates the migration and does NOT contain HMSManagerImpl — bumping now would break installs.",
   "peerDependencies": {
     "@100mslive/react-native-hms": ">=1.12.0 <2.0.0",
     "react": "*",
     "react-native": "*"
+  },
+  "codegenConfig": {
+    "name": "RNVideoPluginSpec",
+    "type": "modules",
+    "jsSrcsDir": "src/specs",
+    "android": {
+      "javaPackageName": "com.hms.reactnativevideoplugin"
+    },
+    "includesGeneratedCode": false
   },
   "workspaces": [
     "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@100mslive/react-native-video-plugin",
-  "version": "1.1.4",
+  "version": "2.0.0-alpha.0",
   "description": "HMSSDK now provides support for Virtual Background using @100mslive/react-native-video-plugin. It allows users to change their background during a call. Users can choose from a variety of backgrounds or upload their own custom background. It also provides a feature to blur the background.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -124,7 +124,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@100mslive/react-native-hms": ">=1.12.0 <2.0.0",
+    "@100mslive/react-native-hms": "^2.0.0-alpha.1",
     "@commitlint/config-conventional": "^17.0.2",
     "@evilmartians/lefthook": "^1.5.0",
     "@react-native/babel-preset": "0.78.1",
@@ -155,9 +155,8 @@
     "minimatch": "^10.2.1",
     "js-yaml": "^4.1.1"
   },
-  "//peerDependenciesTodo": "TODO: bump @100mslive/react-native-hms peer-dep to >=2.0.0-alpha.X once Phase 1 New Architecture migration is published. The 2.0.0-alpha.0 currently on npm (2023-10-05) predates the migration and does NOT contain HMSManagerImpl — bumping now would break installs.",
   "peerDependencies": {
-    "@100mslive/react-native-hms": ">=1.12.0 <2.0.0",
+    "@100mslive/react-native-hms": "^2.0.0-alpha.1",
     "react": "*",
     "react-native": "*"
   },

--- a/src/modules/ReactNativeVideoPluginModule.ts
+++ b/src/modules/ReactNativeVideoPluginModule.ts
@@ -1,4 +1,5 @@
-import { NativeModules, Platform } from 'react-native';
+import { Platform, TurboModuleRegistry } from 'react-native';
+import type { Spec } from '../specs/NativeReactNativeVideoPlugin';
 
 const LINKING_ERROR =
   `The package '@100mslive/react-native-video-plugin' doesn't seem to be linked. Make sure: \n\n` +
@@ -12,7 +13,8 @@ const IOS_PLATFORM_ERROR =
   'Platform.OS === "android" ? ReactNativeVideoPlugin.nativeModule : null\n' +
   '```';
 
-const ReactNativeVideoPluginModule = NativeModules.ReactNativeVideoPlugin;
+const ReactNativeVideoPluginModule =
+  TurboModuleRegistry.get<Spec>('ReactNativeVideoPlugin');
 
 export const ReactNativeVideoPlugin = {
   get nativeModule() {

--- a/src/specs/NativeReactNativeVideoPlugin.ts
+++ b/src/specs/NativeReactNativeVideoPlugin.ts
@@ -1,0 +1,16 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  changeVirtualBackground(data: Object): Promise<boolean>;
+  enableVideoPlugin(data: Object): Promise<boolean>;
+  disableVideoPlugin(data: Object): Promise<boolean>;
+}
+
+// NOTE: This default export looks unused at JS runtime — the consumer wrapper
+// at src/modules/ReactNativeVideoPluginModule.ts does its own
+// TurboModuleRegistry.get<Spec>(...) call with a Proxy fallback (handles iOS,
+// where this module legitimately doesn't exist). Don't delete it though:
+// React Native's Codegen statically parses this call to extract the module
+// name. Removing it fails codegen with `UnusedModuleInterfaceParserError`.
+export default TurboModuleRegistry.getEnforcing<Spec>('ReactNativeVideoPlugin');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,15 +5,27 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@100mslive/react-native-hms@npm:1.12.0":
-  version: 1.12.0
-  resolution: "@100mslive/react-native-hms@npm:1.12.0"
+"@100mslive/react-native-hms@file:../../100ms-react-native/packages/react-native-hms::locator=%40100mslive%2Freact-native-video-plugin-example%40workspace%3Aexample":
+  version: 1.12.2
+  resolution: "@100mslive/react-native-hms@file:../../100ms-react-native/packages/react-native-hms#../../100ms-react-native/packages/react-native-hms::hash=3a7792&locator=%40100mslive%2Freact-native-video-plugin-example%40workspace%3Aexample"
   dependencies:
     zustand: "npm:^4.3.8"
   peerDependencies:
     react: "*"
     react-native: ">=0.77.3"
-  checksum: 10c0/ca29858b6eae525eda374be54b3e5cce969b2f83498679b69419bb9e91347489f6dacea80914677d60670ce76d39bb507fdbb51dbe8be794f0b1a488d5310bd2
+  checksum: 10c0/aeb1fa886e05dd18ebd44ef8e1e1dda44ddab087fb82aa8c775148143605110dd4792c4e12930b72f640c1032b40c93a395a0a5498ffc4e21ead0a074e4c986b
+  languageName: node
+  linkType: hard
+
+"@100mslive/react-native-hms@npm:>=1.12.0 <2.0.0":
+  version: 1.12.1
+  resolution: "@100mslive/react-native-hms@npm:1.12.1"
+  dependencies:
+    zustand: "npm:^4.3.8"
+  peerDependencies:
+    react: "*"
+    react-native: ">=0.77.3"
+  checksum: 10c0/fa9dfb26f4942d79553647210c66ac850c9a416e2a636f395a3a3725f64a312919d3fa77252446263d81e4a7d2f637892bc276c51083ee949e373e5026c369cd
   languageName: node
   linkType: hard
 
@@ -48,7 +60,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@100mslive/react-native-video-plugin-example@workspace:example"
   dependencies:
-    "@100mslive/react-native-hms": "npm:1.12.0"
+    "@100mslive/react-native-hms": "file:../../100ms-react-native/packages/react-native-hms"
     "@100mslive/react-native-room-kit": "npm:1.2.3"
     "@100mslive/react-native-video-plugin": "workspace:^"
     "@100mslive/types-prebuilt": "npm:0.12.12"
@@ -97,7 +109,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@100mslive/react-native-video-plugin@workspace:."
   dependencies:
-    "@100mslive/react-native-hms": "npm:1.12.0"
+    "@100mslive/react-native-hms": "npm:>=1.12.0 <2.0.0"
     "@commitlint/config-conventional": "npm:^17.0.2"
     "@evilmartians/lefthook": "npm:^1.5.0"
     "@react-native/babel-preset": "npm:0.78.1"
@@ -117,7 +129,7 @@ __metadata:
     turbo: "npm:^1.10.7"
     typescript: "npm:^5.7.3"
   peerDependencies:
-    "@100mslive/react-native-hms": 1.12.0
+    "@100mslive/react-native-hms": ">=1.12.0 <2.0.0"
     react: "*"
     react-native: "*"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,27 +5,15 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@100mslive/react-native-hms@file:../../100ms-react-native/packages/react-native-hms::locator=%40100mslive%2Freact-native-video-plugin-example%40workspace%3Aexample":
-  version: 1.12.2
-  resolution: "@100mslive/react-native-hms@file:../../100ms-react-native/packages/react-native-hms#../../100ms-react-native/packages/react-native-hms::hash=3a7792&locator=%40100mslive%2Freact-native-video-plugin-example%40workspace%3Aexample"
+"@100mslive/react-native-hms@npm:^2.0.0-alpha.1":
+  version: 2.0.0-alpha.1
+  resolution: "@100mslive/react-native-hms@npm:2.0.0-alpha.1"
   dependencies:
     zustand: "npm:^4.3.8"
   peerDependencies:
     react: "*"
     react-native: ">=0.77.3"
-  checksum: 10c0/aeb1fa886e05dd18ebd44ef8e1e1dda44ddab087fb82aa8c775148143605110dd4792c4e12930b72f640c1032b40c93a395a0a5498ffc4e21ead0a074e4c986b
-  languageName: node
-  linkType: hard
-
-"@100mslive/react-native-hms@npm:>=1.12.0 <2.0.0":
-  version: 1.12.1
-  resolution: "@100mslive/react-native-hms@npm:1.12.1"
-  dependencies:
-    zustand: "npm:^4.3.8"
-  peerDependencies:
-    react: "*"
-    react-native: ">=0.77.3"
-  checksum: 10c0/fa9dfb26f4942d79553647210c66ac850c9a416e2a636f395a3a3725f64a312919d3fa77252446263d81e4a7d2f637892bc276c51083ee949e373e5026c369cd
+  checksum: 10c0/c4dd2112bb9b9fc791482f986b39da4b25931b314ca6a212fac54ec2d46d16e632305399ca7b07b570dc421b97965667a6fb8400636f433f342e2ff908497939
   languageName: node
   linkType: hard
 
@@ -60,7 +48,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@100mslive/react-native-video-plugin-example@workspace:example"
   dependencies:
-    "@100mslive/react-native-hms": "file:../../100ms-react-native/packages/react-native-hms"
+    "@100mslive/react-native-hms": "npm:^2.0.0-alpha.1"
     "@100mslive/react-native-room-kit": "npm:1.2.3"
     "@100mslive/react-native-video-plugin": "workspace:^"
     "@100mslive/types-prebuilt": "npm:0.12.12"
@@ -109,7 +97,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@100mslive/react-native-video-plugin@workspace:."
   dependencies:
-    "@100mslive/react-native-hms": "npm:>=1.12.0 <2.0.0"
+    "@100mslive/react-native-hms": "npm:^2.0.0-alpha.1"
     "@commitlint/config-conventional": "npm:^17.0.2"
     "@evilmartians/lefthook": "npm:^1.5.0"
     "@react-native/babel-preset": "npm:0.78.1"
@@ -129,7 +117,7 @@ __metadata:
     turbo: "npm:^1.10.7"
     typescript: "npm:^5.7.3"
   peerDependencies:
-    "@100mslive/react-native-hms": ">=1.12.0 <2.0.0"
+    "@100mslive/react-native-hms": ^2.0.0-alpha.1
     react: "*"
     react-native: "*"
   languageName: unknown


### PR DESCRIPTION
## Summary

Phase 1 New Architecture (Fabric + TurboModules + bridgeless) migration, aligned with [`@100mslive/react-native-hms@2.0.0-alpha.1`](https://www.npmjs.com/package/@100mslive/react-native-hms/v/2.0.0-alpha.1). Single Android module, no view managers, no iOS native — minimal surface, mostly mechanical.

### What changed

- **TurboModule TS spec** (`src/specs/NativeReactNativeVideoPlugin.ts`) — declares the 3 methods (`changeVirtualBackground`, `enableVideoPlugin`, `disableVideoPlugin`). Codegen reads this to generate the Java abstract base class.
- **`codegenConfig`** in `package.json` — points codegen at the spec, names the generated Java package.
- **Android: wrapper-with-shared-impl split** — actual SDK logic lives in `ReactNativeVideoPluginModuleImpl.kt` (plain class, no parent). Two thin wrappers — `oldarch/` extends `ReactContextBaseJavaModule`, `newarch/` extends codegen-generated `NativeReactNativeVideoPluginSpec`. Gradle sourceSets switch picks one per build.
- **`ReactNativeVideoPluginPackage.kt`** — switched from `ReactPackage` to `BaseReactPackage` with TurboModule-aware lazy registration (`getReactModuleInfoProvider`).
- **`android/build.gradle`** — modern `plugins {}` DSL block, codegen `react {}` block, sourceSets switch keyed on `newArchEnabled`.
- **JS module wrapper** — `TurboModuleRegistry.get<Spec>` (non-enforcing) instead of `NativeModules.X`. Kept the Proxy fallback so iOS (where this Android-only module legitimately doesn't exist) gets a friendly error instead of an import-time crash.
- **`HMSManager.hmsCollection` → `HMSManagerImpl.hmsCollection`** — single line in the Impl; the sibling moved its canonical SDK-instance map during its Phase 1, we follow.
- **Peer-dep** widened to `^2.0.0-alpha.1` (excludes the stale `2.0.0-alpha.0` from 2023 that predates the migration).
- **Version** bumped to `2.0.0-alpha.0` — major to signal the breaking peer-dep change, alpha track because we depend on hms's alpha.
- **Example app** — peer-dep on hms updated, plus a root-buildscript classpath workaround + `includeBuild` for `react-native-gradle-plugin` so transitive libs (`lottie-react-native`) using legacy `apply plugin:` syntax resolve under new-arch builds. Not in the published library.

### Verification

| Build | Result |
|---|---|
| `yarn typecheck` | ✅ |
| Android `assembleDebug -PnewArchEnabled=false` | ✅ |
| Android `assembleDebug -PnewArchEnabled=true` | ✅ |

Verified against published `@100mslive/react-native-hms@2.0.0-alpha.1`.

### Deviations from sibling pattern (intentional)

1. JS module uses `TurboModuleRegistry.get<Spec>` (non-enforcing) + Proxy fallback instead of `getEnforcing`. Reason: no iOS native module in this repo — `getEnforcing` would crash at import time on iOS before any user code runs. The Proxy gives a diagnostic error on first method call instead.
2. `codegenConfig.type` is `modules` (not `all`) — no view components here.